### PR TITLE
Fix Database 2 name in readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -61,7 +61,7 @@ Password: <It's blank.  As in literally blank.  Don't put all of this in there.>
 User: postgres
 Host/Socket: 127.0.0.1
 Port: 5433
-Database: practical_microservices
+Database: message_store
 Password: <It's blank.  As in literally blank.  Don't put all of this in there.>
 ```
 


### PR DESCRIPTION
The database inside the "Database 2" instance (on port 5433) seems to be called `message_store`?